### PR TITLE
:bug: Fix gqlStop empty payload mishandling

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -661,14 +661,18 @@ func (c *Conn) processIncomeMessage(operationMessage *OperationMessage) {
 	case gqlTypeStop:
 		logger.Trace(TraceLevelInternalGQLMessages, "gqlStop: ", string(operationMessage.Payload))
 
-		var stop GQLStop
-		err := json.Unmarshal(operationMessage.Payload, &stop)
-		if err != nil {
-			// TODO
-			panic(err)
+		if len(operationMessage.Payload) > 0 {
+			var stop GQLStop
+			err := json.Unmarshal(operationMessage.Payload, &stop)
+			if err != nil {
+				// TODO
+				panic(err)
+			}
+			c.gqlStop(&stop)
+			return
 		}
+		c.close()
 
-		c.gqlStop(&stop)
 	default:
 		// TODO To call a default error handler or, maybe, a default message handler.
 	}


### PR DESCRIPTION
**Bugs**

* Handle empty gqlStop payloads. Now they end the connection gracefully;
* Fix a problem identified during tests: the "shutdown message" was being missed due to concurrency problems. A `sleep` was added to give some time between calls :poop::poop:.